### PR TITLE
Implement player nickname authorization

### DIFF
--- a/wechat-minigame/pages/room/room.js
+++ b/wechat-minigame/pages/room/room.js
@@ -4,31 +4,34 @@ Page({
   data: {
     roomId: '',
     players: [],
-    isHost: false
+    isHost: false,
+    userReady: false
   },
   onLoad(options) {
     const { roomId = '', host } = options;
     this.setData({ roomId, isHost: host === '1' });
 
-    const finish = () => {
+    if (app.globalData.userInfo) {
+      this.setData({ userReady: true });
       this.initRoom();
-    };
-
-    if (!app.globalData.userInfo) {
-      wx.getUserProfile({
-        desc: '展示玩家名称',
-        success: res => {
-          app.globalData.userInfo = res.userInfo;
-          finish();
-        },
-        fail: () => {
-          app.globalData.userInfo = { nickName: '游客' + Math.floor(Math.random() * 1000) };
-          finish();
-        }
-      });
-    } else {
-      finish();
     }
+  },
+  handleAuth() {
+    wx.getUserProfile({
+      desc: '展示玩家名称',
+      success: res => {
+        app.globalData.userInfo = res.userInfo;
+        this.afterAuth();
+      },
+      fail: () => {
+        app.globalData.userInfo = { nickName: '游客' + Math.floor(Math.random() * 1000) };
+        this.afterAuth();
+      }
+    });
+  },
+  afterAuth() {
+    this.setData({ userReady: true });
+    this.initRoom();
   },
   onShow() {
     const room = app.globalData.rooms[this.data.roomId];

--- a/wechat-minigame/pages/room/room.wxml
+++ b/wechat-minigame/pages/room/room.wxml
@@ -2,8 +2,12 @@
   <text class="room-title">房间ID: {{roomId}}</text>
   <view class="players">
     <text>玩家人数: {{players.length}} / 4</text>
-    <view wx:for="{{players}}" wx:key="index">{{item}}</view>
+    <view wx:for="{{players}}" wx:key="name" class="player-item">{{item.name}}</view>
   </view>
   <button wx:if="{{isHost}}" open-type="share">邀请好友</button>
   <button wx:if="{{isHost}}" bindtap="startGame" disabled="{{players.length<4}}">开始游戏</button>
+
+  <view wx:if="{{!userReady}}" class="auth-mask">
+    <button bindtap="handleAuth">授权进入房间</button>
+  </view>
 </view>

--- a/wechat-minigame/pages/room/room.wxss
+++ b/wechat-minigame/pages/room/room.wxss
@@ -8,3 +8,19 @@
 .players {
   margin-bottom: 40rpx;
 }
+
+.player-item {
+  margin-top: 10rpx;
+}
+
+.auth-mask {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.6);
+}


### PR DESCRIPTION
## Summary
- prompt player to authorize WeChat profile when joining a room
- show real nickname if authorized or fallback to guest nickname
- display player names correctly in the room
- add styles for authorization overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c912536cc832ea400cc6d2e89d3e0