### PR TITLE
Implement initial nickname authorization

### DIFF
--- a/wechat-minigame/app.js
+++ b/wechat-minigame/app.js
@@ -1,4 +1,10 @@
 App({
+  onLaunch() {
+    const info = wx.getStorageSync('userInfo');
+    if (info) {
+      this.globalData.userInfo = info;
+    }
+  },
   globalData: {
     rooms: {},
     userInfo: null

--- a/wechat-minigame/components/auth-mask/auth-mask.js
+++ b/wechat-minigame/components/auth-mask/auth-mask.js
@@ -1,0 +1,28 @@
+Component({
+  properties: {
+    visible: {
+      type: Boolean,
+      value: false
+    }
+  },
+  methods: {
+    handleAuth() {
+      wx.getUserProfile({
+        desc: '展示玩家名称',
+        success: res => {
+          const app = getApp();
+          app.globalData.userInfo = res.userInfo;
+          wx.setStorageSync('userInfo', res.userInfo);
+          this.triggerEvent('authed');
+        },
+        fail: () => {
+          const app = getApp();
+          const nick = '游客' + Math.floor(Math.random() * 1000);
+          app.globalData.userInfo = { nickName: nick };
+          wx.setStorageSync('userInfo', app.globalData.userInfo);
+          this.triggerEvent('authed');
+        }
+      });
+    }
+  }
+});

--- a/wechat-minigame/components/auth-mask/auth-mask.json
+++ b/wechat-minigame/components/auth-mask/auth-mask.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/wechat-minigame/components/auth-mask/auth-mask.wxml
+++ b/wechat-minigame/components/auth-mask/auth-mask.wxml
@@ -1,0 +1,3 @@
+<view wx:if="{{visible}}" class="auth-mask">
+  <button bindtap="handleAuth" class="auth-btn">授权获取昵称</button>
+</view>

--- a/wechat-minigame/components/auth-mask/auth-mask.wxss
+++ b/wechat-minigame/components/auth-mask/auth-mask.wxss
@@ -1,0 +1,15 @@
+.auth-mask {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+}
+.auth-btn {
+  padding: 20rpx 40rpx;
+}

--- a/wechat-minigame/pages/game/game.js
+++ b/wechat-minigame/pages/game/game.js
@@ -2,10 +2,14 @@ const app = getApp();
 
 Page({
   data: {
-    players: []
+    players: [],
+    showAuth: false
   },
   onLoad(options) {
     this.roomId = options.roomId || '';
+    if (!app.globalData.userInfo) {
+      this.setData({ showAuth: true });
+    }
   },
   onShow() {
     this.update();
@@ -42,5 +46,8 @@ Page({
   },
   onTouchEnd() {
     this.dragIndex = undefined;
+  },
+  onAuthed() {
+    this.setData({ showAuth: false });
   }
 });

--- a/wechat-minigame/pages/game/game.json
+++ b/wechat-minigame/pages/game/game.json
@@ -1,3 +1,6 @@
 {
-  "navigationBarTitleText": "星际探索"
+  "navigationBarTitleText": "星际探索",
+  "usingComponents": {
+    "auth-mask": "/components/auth-mask/auth-mask"
+  }
 }

--- a/wechat-minigame/pages/game/game.wxml
+++ b/wechat-minigame/pages/game/game.wxml
@@ -12,3 +12,4 @@
     {{item.name}}
   </view>
 </view>
+<auth-mask visible="{{showAuth}}" bind:authed="onAuthed" />

--- a/wechat-minigame/pages/index/index.js
+++ b/wechat-minigame/pages/index/index.js
@@ -1,6 +1,14 @@
 const app = getApp();
 
 Page({
+  data: {
+    showAuth: false
+  },
+  onLoad() {
+    if (!app.globalData.userInfo) {
+      this.setData({ showAuth: true });
+    }
+  },
   createRoom() {
     const roomId = Date.now().toString();
     wx.navigateTo({
@@ -12,5 +20,8 @@ Page({
       title: '星际探索房间',
       path: '/pages/index/index'
     }
+  },
+  onAuthed() {
+    this.setData({ showAuth: false });
   }
 });

--- a/wechat-minigame/pages/index/index.json
+++ b/wechat-minigame/pages/index/index.json
@@ -1,3 +1,6 @@
 {
-  "navigationBarTitleText": "星际探索"
+  "navigationBarTitleText": "星际探索",
+  "usingComponents": {
+    "auth-mask": "/components/auth-mask/auth-mask"
+  }
 }

--- a/wechat-minigame/pages/index/index.wxml
+++ b/wechat-minigame/pages/index/index.wxml
@@ -1,4 +1,5 @@
 <view class="container">
   <text class="title">星际探索</text>
-  <button bindtap="createRoom">邀请好友</button>
+<button bindtap="createRoom">邀请好友</button>
 </view>
+<auth-mask visible="{{showAuth}}" bind:authed="onAuthed" />

--- a/wechat-minigame/pages/loading/loading.js
+++ b/wechat-minigame/pages/loading/loading.js
@@ -1,8 +1,14 @@
+const app = getApp();
+
 Page({
   data: {
-    progress: 0
+    progress: 0,
+    showAuth: false
   },
   onLoad() {
+    if (!app.globalData.userInfo) {
+      this.setData({ showAuth: true });
+    }
     this.timer = setInterval(() => {
       let p = this.data.progress + 5;
       if (p > 100) {
@@ -15,5 +21,8 @@ Page({
   },
   onUnload() {
     clearInterval(this.timer);
+  },
+  onAuthed() {
+    this.setData({ showAuth: false });
   }
 });

--- a/wechat-minigame/pages/loading/loading.json
+++ b/wechat-minigame/pages/loading/loading.json
@@ -1,3 +1,6 @@
 {
-  "navigationBarTitleText": "加载"
+  "navigationBarTitleText": "加载",
+  "usingComponents": {
+    "auth-mask": "/components/auth-mask/auth-mask"
+  }
 }

--- a/wechat-minigame/pages/loading/loading.wxml
+++ b/wechat-minigame/pages/loading/loading.wxml
@@ -2,3 +2,4 @@
   <text>加载中... {{progress}}%</text>
   <progress percent="{{progress}}" show-info/>
 </view>
+<auth-mask visible="{{showAuth}}" bind:authed="onAuthed" />

--- a/wechat-minigame/pages/room/room.js
+++ b/wechat-minigame/pages/room/room.js
@@ -5,7 +5,8 @@ Page({
     roomId: '',
     players: [],
     isHost: false,
-    userReady: false
+    userReady: false,
+    showAuth: false
   },
   onLoad(options) {
     const { roomId = '', host } = options;
@@ -14,23 +15,12 @@ Page({
     if (app.globalData.userInfo) {
       this.setData({ userReady: true });
       this.initRoom();
+    } else {
+      this.setData({ showAuth: true });
     }
   },
-  handleAuth() {
-    wx.getUserProfile({
-      desc: '展示玩家名称',
-      success: res => {
-        app.globalData.userInfo = res.userInfo;
-        this.afterAuth();
-      },
-      fail: () => {
-        app.globalData.userInfo = { nickName: '游客' + Math.floor(Math.random() * 1000) };
-        this.afterAuth();
-      }
-    });
-  },
-  afterAuth() {
-    this.setData({ userReady: true });
+  onAuthed() {
+    this.setData({ userReady: true, showAuth: false });
     this.initRoom();
   },
   onShow() {

--- a/wechat-minigame/pages/room/room.json
+++ b/wechat-minigame/pages/room/room.json
@@ -1,3 +1,6 @@
 {
-  "navigationBarTitleText": "房间"
+  "navigationBarTitleText": "房间",
+  "usingComponents": {
+    "auth-mask": "/components/auth-mask/auth-mask"
+  }
 }

--- a/wechat-minigame/pages/room/room.wxml
+++ b/wechat-minigame/pages/room/room.wxml
@@ -6,8 +6,5 @@
   </view>
   <button wx:if="{{isHost}}" open-type="share">邀请好友</button>
   <button wx:if="{{isHost}}" bindtap="startGame" disabled="{{players.length<4}}">开始游戏</button>
-
-  <view wx:if="{{!userReady}}" class="auth-mask">
-    <button bindtap="handleAuth">授权进入房间</button>
-  </view>
+  <auth-mask visible="{{showAuth}}" bind:authed="onAuthed" />
 </view>

--- a/wechat-minigame/pages/room/room.wxss
+++ b/wechat-minigame/pages/room/room.wxss
@@ -13,14 +13,3 @@
   margin-top: 10rpx;
 }
 
-.auth-mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: rgba(0, 0, 0, 0.6);
-}


### PR DESCRIPTION
## Summary
- add `auth-mask` component to request nickname via `wx.getUserProfile`
- persist user info on launch
- show auth mask when user info is missing on all pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e05cfdb6c832eabbec1f527337c7f